### PR TITLE
Updated to Scala 2.13.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name         := "language-library"
 organization := "org.nlogo.languagelibrary"
-version      := "2.4.0"
+version      := "3.0.0"
 isSnapshot   := true
 
-scalaVersion          := "2.12.12"
+scalaVersion          := "2.13.16"
 scalacOptions        ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings", "-Xlint", "-release", "11")
 Compile / scalaSource := baseDirectory.value / "src"
 
@@ -11,7 +11,7 @@ resolvers += "netlogo" at "https://dl.cloudsmith.io/public/netlogo/netlogo/maven
 
 libraryDependencies ++= Seq(
   "org.nlogo"          % "netlogo"        % "6.3.0"
-, "org.json4s"        %% "json4s-jackson" % "3.5.3"
+, "org.json4s"        %% "json4s-jackson" % "4.0.7"
 // not used by this library, but needed for NetLogo
 , "org.jogamp.jogl" % "jogl-all" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0/jar/jogl-all.jar"
 , "org.jogamp.gluegen" % "gluegen-rt" % "2.4.0" from "https://jogamp.org/deployment/archive/rc/v2.4.0/jar/gluegen-rt.jar"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.9.7

--- a/src/org/nlogo/langextension/ShellWindow.scala
+++ b/src/org/nlogo/langextension/ShellWindow.scala
@@ -118,7 +118,7 @@ class ShellWindow extends JFrame with KeyListener with ActionListener {
 
   // -------------------------Listeners----------------------------------------
 
-  override def actionPerformed(e: ActionEvent) {
+  override def actionPerformed(e: ActionEvent): Unit = {
     val command = e.getActionCommand
     menuItemCallbacks get command match {
       case Some(callback) => callback(e)

--- a/src/org/nlogo/langextension/config/ConfigEditor.scala
+++ b/src/org/nlogo/langextension/config/ConfigEditor.scala
@@ -45,6 +45,6 @@ class ConfigEditor(owner: JFrame, longName: String, extLangBin: String, config: 
     properties.foreach( (prop) => {
       config.set(prop.key, prop.value)
     })
-    config.save
+    config.save()
   }
 }


### PR DESCRIPTION
This PR updates the library to Scala 2.13.16, so that it will work with the main repo. See PR [#2394](https://github.com/NetLogo/NetLogo/pull/2394) for the corresponding changes in the main NetLogo repo and bundled extensions.